### PR TITLE
add warn/trip level to meter response (#120)

### DIFF
--- a/DCCEXParser.cpp
+++ b/DCCEXParser.cpp
@@ -441,10 +441,10 @@ void DCCEXParser::parse(Print *stream, byte *com, bool blocking)
         }
         return;
 
-    case 'c': // READ CURRENT <c>
-        //                               <c MeterName val C/V unit min max res>
-        StringFormatter::send(stream, F("<c CurrentMAIN %d C Milli 0 %d 1>"), DCCWaveform::mainTrack.getCurrentmA(), DCCWaveform::mainTrack.getMaxmA());
-     // StringFormatter::send(stream, F("<c CurrentPROG %d C Milli 0 %d 1>"), DCCWaveform::progTrack.getCurrentmA(), DCCWaveform::progTrack.getMaxmA());        
+    case 'c': // SEND METER RESPONSES <c>
+        //                               <c MeterName value C/V unit min max res warn>
+        StringFormatter::send(stream, F("<c CurrentMAIN %d C Milli 0 %d 1 %d>"), DCCWaveform::mainTrack.getCurrentmA(), 
+            DCCWaveform::mainTrack.getMaxmA(), DCCWaveform::mainTrack.getTripmA());
         StringFormatter::send(stream, F("<a %d>"), DCCWaveform::mainTrack.get1024Current()); //'a' message deprecated, remove once JMRI 4.22 is available
         return;
 

--- a/DCCWaveform.h
+++ b/DCCWaveform.h
@@ -69,9 +69,15 @@ class DCCWaveform {
     }
     inline int getMaxmA() {
       if (maxmA == 0) { //only calculate this for first request, it doesn't change
-        maxmA = motorDriver->raw2mA(motorDriver->getRawCurrentTripValue());
+        maxmA = motorDriver->raw2mA(motorDriver->getRawCurrentTripValue()); //TODO: replace with actual max value or calc
       }
       return maxmA;        
+    }
+    inline int getTripmA() { 
+      if (tripmA == 0) { //only calculate this for first request, it doesn't change
+        tripmA = motorDriver->raw2mA(motorDriver->getRawCurrentTripValue());
+      }
+      return tripmA;        
     }
     void schedulePacket(const byte buffer[], byte byteCount, byte repeats);
     volatile bool packetPending;
@@ -124,6 +130,7 @@ class DCCWaveform {
     byte pendingRepeats;
     int lastCurrent;
     int maxmA;
+    int tripmA;
     
     // current sampling
     POWERMODE powerMode;


### PR DESCRIPTION
* send milliAmps and meter setup for new JMRI Meter function

* add warn/trip level to meter response

provides support for separate max vs trip levels